### PR TITLE
Add MIT license reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Install dependencies with:
 pip install -r requirements.txt
 ```
 
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- reference MIT license in README

## Testing
- `python -m py_compile codigo.py`


------
https://chatgpt.com/codex/tasks/task_e_685b81a302b0832d8b7fd23157a11038